### PR TITLE
✨ 홈 화면 api 데이터 연동 

### DIFF
--- a/src/components/home/Card.tsx
+++ b/src/components/home/Card.tsx
@@ -4,19 +4,13 @@ import Link from "next/link";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutline";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
-import { Post } from "../../types/Post";
-
-import { useRouter } from "next/router";
 
 import { PostModal } from "./PostModal";
 import { DeleteModal } from "./DeleteModal";
 
+export const Card = ({ postData }: any) => {
+  const { author, image, content, createdAt } = postData;
 
-interface PostProps {
-  postData: Post;
-}
-
-export const Card = ({ postData }: PostProps) => {
   const [likeNum, setLikeNum] = useState(0);
   const [checkClick, setCheckClick] = useState(true);
   const [heartColor, setHeartColor] = useState("icon");
@@ -60,19 +54,19 @@ export const Card = ({ postData }: PostProps) => {
         <h3 className="sr-only">포스트 아이템</h3>
         <AuthorCont>
           <h4 className="sr-only">포스트 글쓴이</h4>
-          <AuthorImg src={postData.src} alt="작성자 이미지" />
+          <AuthorImg src={author.image} alt="작성자 이미지" />
           <AuthorInfo>
-            <AuthorNickName>{postData.nickname}</AuthorNickName>
-            <AuthorId>{postData.email}</AuthorId>
+            <AuthorNickName>{author.accountname}</AuthorNickName>
+            <AuthorId>{author.accountname}</AuthorId>
           </AuthorInfo>
         </AuthorCont>
         <PostCont>
           <h4 className="sr-only">포스트 내용</h4>
-          <PostTxt>{postData.txt}</PostTxt>
+          <PostTxt>{content}</PostTxt>
           <PostImgCont>
             <PostImgList>
               <PostImgItem>
-                <PostImg src={postData.postimg} alt="post-img" />
+                <PostImg src={image} alt="post-img" />
               </PostImgItem>
             </PostImgList>
           </PostImgCont>
@@ -87,8 +81,8 @@ export const Card = ({ postData }: PostProps) => {
                 pathname: `/postdetail/${postData.id}`,
                 query: {
                   title: postData.txt,
-                  nickname: postData.nickname
-                }
+                  nickname: postData.nickname,
+                },
               }}
               as={`/postdetail/${postData.id}`}
             >
@@ -99,7 +93,7 @@ export const Card = ({ postData }: PostProps) => {
               </Comment>
             </Link>
           </LikeCommentCont>
-          <PostDate>{postData.postdate}</PostDate>
+          <PostDate>{createdAt}</PostDate>
         </PostCont>
         <MoreBtn onClick={openPostModal}>
           <span className="sr-only">더보기 버튼</span>

--- a/src/components/home/CardContainer.tsx
+++ b/src/components/home/CardContainer.tsx
@@ -1,102 +1,14 @@
 import { Card } from "./Card";
+import { Posts } from "../../types/Posts";
 
-export const CardContainer = () => {
-  const postData = [
-    {
-      id: 1,
-      src: "https://img1.daumcdn.net/thumb/R1280x0.fjpg/?fname=http://t1.daumcdn.net/brunch/service/user/cnoC/image/bA15rm1zOffsle8EVMPD_ZHtxYU.JPG",
-      nickname: "리액트 과몰입러",
-      email: "dlgusgh200240",
-      txt: "아름다운 베니스의 일상",
-      postimg:
-        "https://img1.daumcdn.net/thumb/R1280x0.fjpg/?fname=http://t1.daumcdn.net/brunch/service/user/cnoC/image/bA15rm1zOffsle8EVMPD_ZHtxYU.JPG",
-      postdate: "2022년 1월 17일",
-    },
-    {
-      id: 2,
-      src: "https://cdn.pixabay.com/photo/2020/03/25/16/01/children-4967808_960_720.jpg",
-      nickname: "리액트 과몰입러",
-      email: "dlgusgh200240",
-      txt: "아름다운 베니스의 일상",
-      postimg:
-        "https://cdn.pixabay.com/photo/2018/07/18/20/25/channel-3547224_960_720.jpg",
-      postdate: "2022년 1월 17일",
-    },
-    {
-      id: 3,
-      src: "https://cdn.pixabay.com/photo/2020/03/25/16/01/children-4967808_960_720.jpg",
-      nickname: "리액트 과몰입러",
-      email: "dlgusgh200240",
-      txt: "아름다운 베니스의 일상",
-      postimg:
-        "https://cdn.pixabay.com/photo/2018/07/18/20/25/channel-3547224_960_720.jpg",
-      postdate: "2022년 1월 17일",
-    },
-    {
-      id: 4,
-      src: "https://cdn.pixabay.com/photo/2020/03/25/16/01/children-4967808_960_720.jpg",
-      nickname: "리액트 과몰입러",
-      email: "dlgusgh200240",
-      txt: "아름다운 베니스의 일상",
-      postimg:
-        "https://cdn.pixabay.com/photo/2018/07/18/20/25/channel-3547224_960_720.jpg",
-      postdate: "2022년 1월 17일",
-    },
-    {
-      id: 5,
-      src: "https://cdn.pixabay.com/photo/2020/03/25/16/01/children-4967808_960_720.jpg",
-      nickname: "리액트 과몰입러",
-      email: "dlgusgh200240",
-      txt: "아름다운 베니스의 일상",
-      postimg:
-        "https://cdn.pixabay.com/photo/2018/07/18/20/25/channel-3547224_960_720.jpg",
-      postdate: "2022년 1월 17일",
-    },
-    {
-      id: 6,
-      src: "https://cdn.pixabay.com/photo/2020/03/25/16/01/children-4967808_960_720.jpg",
-      nickname: "리액트 과몰입러",
-      email: "dlgusgh200240",
-      txt: "아름다운 베니스의 일상",
-      postimg:
-        "https://cdn.pixabay.com/photo/2018/07/18/20/25/channel-3547224_960_720.jpg",
-      postdate: "2022년 1월 17일",
-    },
-    {
-      id: 7,
-      src: "https://cdn.pixabay.com/photo/2020/03/25/16/01/children-4967808_960_720.jpg",
-      nickname: "리액트 과몰입러",
-      email: "dlgusgh200240",
-      txt: "아름다운 베니스의 일상",
-      postimg:
-        "https://cdn.pixabay.com/photo/2018/07/18/20/25/channel-3547224_960_720.jpg",
-      postdate: "2022년 1월 17일",
-    },
-    {
-      id: 8,
-      src: "https://cdn.pixabay.com/photo/2020/03/25/16/01/children-4967808_960_720.jpg",
-      nickname: "리액트 과몰입러",
-      email: "dlgusgh200240",
-      txt: "아름다운 베니스의 일상",
-      postimg:
-        "https://cdn.pixabay.com/photo/2018/07/18/20/25/channel-3547224_960_720.jpg",
-      postdate: "2022년 1월 17일",
-    },
-    {
-      id: 9,
-      src: "https://cdn.pixabay.com/photo/2020/03/25/16/01/children-4967808_960_720.jpg",
-      nickname: "리액트 과몰입러",
-      email: "dlgusgh200240",
-      txt: "아름다운 베니스의 일상",
-      postimg:
-        "https://cdn.pixabay.com/photo/2018/07/18/20/25/channel-3547224_960_720.jpg",
-      postdate: "2022년 1월 17일",
-    },
-  ];
+interface PostData {
+  postData: Posts;
+}
 
+export const CardContainer = ({ postData }: PostData) => {
   return (
     <div>
-      {postData.map((postData) => {
+      {postData.map((postData: any) => {
         return <Card key={postData.id} postData={postData} />;
       })}
     </div>

--- a/src/components/home/Main.tsx
+++ b/src/components/home/Main.tsx
@@ -2,54 +2,66 @@ import styled from "@emotion/styled";
 import { useEffect, useState } from "react";
 import { CardContainer } from "./CardContainer";
 import { NonFeed } from "../home/Nonfeed";
-import { getSession } from "next-auth/react";
-import { Session } from "next-auth";
+import { useSession } from "next-auth/react";
 import axios from "axios";
 import { API_ENDPOINT } from "../../constants";
-import { useData } from "../../hooks/useMandarinData";
 
 export const Main = () => {
-  const [showing, setShowing] = useState(false);
-  const [user, setUser] = useState<Session | null>();
-  const session = async () => {
-    const data = await getSession();
-    return data;
-  };
+  const [postData, setPostData] = useState([
+    {
+      author: {
+        accountname: "",
+        // follower: [],
+        // followerCount: "",
+        // following: "",
+        // followingCount: 0,
+        image: "",
+        // intro: "",
+        // isfollow: false,
+        username: "",
+        _id: "",
+      },
+      commentCount: 0,
+      comments: [],
+      content: "",
+      createdAt: "",
+      heartCount: 0,
+      hearted: false,
+      id: "",
+      image: "",
+      updatedAt: "",
+    },
+  ]);
 
-  useEffect(() => {
-    session().then((data: Session | null) => setUser(data));
-  }, []);
+  const { data: session } = useSession();
 
-  // const [user, setUser] = useState<Session | null>();
-  // const session = async () => {
-  //   const data = await getSession();
-  //   console.log(data);
-  //   return data;
-  // };
-
-  // useEffect(() => {
-  //   session().then((data: Session | null) => setUser(data));
-  // }, []);
+  const token = session?.user?.name;
 
   const userData = async () => {
     try {
       const res: any = await axios.get(API_ENDPOINT + "post/feed/", {
         headers: {
-          Authorization: `Bearer ${user?.user?.name}`,
+          Authorization: `Bearer ${token}`,
           "Content-type": "application/json",
         },
       });
-      console.log(res);
+      setPostData(res.data.posts);
     } catch (e) {
       console.log(e);
     }
   };
-  userData();
+  useEffect(() => {
+    userData();
+  }, []);
 
   return (
     <MainContainer>
       <h2 className="sr-only">감귤마켓 피드</h2>
-      {showing ? <NonFeed /> : <CardContainer />}
+      {postData.length === 0 ? (
+        <NonFeed />
+      ) : (
+        <CardContainer postData={postData} />
+      )}
     </MainContainer>
   );
 };
@@ -62,6 +74,3 @@ const MainContainer = styled.main`
   overflow-y: scroll;
   padding: 20px 16px 0;
 `;
-function res(res: any) {
-  throw new Error("Function not implemented.");
-}

--- a/src/components/home/Main.tsx
+++ b/src/components/home/Main.tsx
@@ -4,10 +4,12 @@ import { CardContainer } from "./CardContainer";
 import { NonFeed } from "../home/Nonfeed";
 import { getSession } from "next-auth/react";
 import { Session } from "next-auth";
+import axios from "axios";
+import { API_ENDPOINT } from "../../constants";
+import { useData } from "../../hooks/useMandarinData";
 
 export const Main = () => {
   const [showing, setShowing] = useState(false);
-
   const [user, setUser] = useState<Session | null>();
   const session = async () => {
     const data = await getSession();
@@ -17,6 +19,32 @@ export const Main = () => {
   useEffect(() => {
     session().then((data: Session | null) => setUser(data));
   }, []);
+
+  // const [user, setUser] = useState<Session | null>();
+  // const session = async () => {
+  //   const data = await getSession();
+  //   console.log(data);
+  //   return data;
+  // };
+
+  // useEffect(() => {
+  //   session().then((data: Session | null) => setUser(data));
+  // }, []);
+
+  const userData = async () => {
+    try {
+      const res: any = await axios.get(API_ENDPOINT + "post/feed/", {
+        headers: {
+          Authorization: `Bearer ${user?.user?.name}`,
+          "Content-type": "application/json",
+        },
+      });
+      console.log(res);
+    } catch (e) {
+      console.log(e);
+    }
+  };
+  userData();
 
   return (
     <MainContainer>
@@ -34,3 +62,6 @@ const MainContainer = styled.main`
   overflow-y: scroll;
   padding: 20px 16px 0;
 `;
+function res(res: any) {
+  throw new Error("Function not implemented.");
+}

--- a/src/pages/postdetail/[id].tsx
+++ b/src/pages/postdetail/[id].tsx
@@ -2,7 +2,6 @@ import type { NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { PostDetailContainer } from "../../components/postDetail/Container";
-import { Post } from "../../types/Post";
 
 const PostDetail: NextPage = () => {
   return (

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -1,9 +1,0 @@
-export interface Post {
-  id: number;
-  src: string;
-  nickname: string;
-  email: string;
-  txt: string;
-  postimg: string;
-  postdate: string;
-}

--- a/src/types/Posts.ts
+++ b/src/types/Posts.ts
@@ -1,0 +1,25 @@
+export interface Posts {
+  map(arg0: (postData: any) => JSX.Element): import("react").ReactNode;
+  author: {
+    accountname: string;
+    username: string;
+    // follower: string[];
+    // followerCount: number;
+    // following: string[];
+    // followingCount: number;
+    image: string;
+    // intro: string;
+    // isfollow: boolean;
+    // username: string;
+    _id: string;
+  };
+  commentCount: number;
+  comments: string[];
+  content: string;
+  createdAt: string;
+  heartCount: number;
+  hearted: boolean;
+  id: string;
+  image: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## 세부 사항
- 홈 화면에서 팔로우한 유저가있을 때와 없을 때 나누어서 다른 화면을 보여주게 구현하였습니다.
- 팔로우한 유저가 없을 때는 유저 검색하기라는 화면을 띄어주도록 하였습니다.
- 팔로우한 유저가 있을 때는 팔로우한 유저의 게시글을 볼 수 있게 해주었습니다.

## 기타 질문 및 특이 사항
- 게시글 이미지가 2개 이상일 때 이미지가 제대로 보여지지 않습니다. 추후 캐러셀로 구현해야할 것 같습니다.
 
## 체크 리스트 
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.